### PR TITLE
array can have max size of PTRDIFF_MAX. 

### DIFF
--- a/array.cpp
+++ b/array.cpp
@@ -4,7 +4,7 @@
 
 int main()
 {
-  ca::array<int, 4> ca;
+  ca::array<int, 3> ca;
 
   ca.push_front(1);
   ca.push_back(2);

--- a/arrayiterator.hpp
+++ b/arrayiterator.hpp
@@ -75,7 +75,7 @@ public:
       {
         auto d(p - f);
 
-        if (d < 0) d = &a[CA::cap - 1] - f + (p - a + 1);
+        if (d < 0) d = &a[CA::N] - f + (p - a);
 
         return d;
       }
@@ -117,7 +117,7 @@ public:
       {
         auto d(p - f);
 
-        if (d < 0) d = &a[CA::cap - 1] - f + (p - a + 1);
+        if (d < 0) d = &a[CA::N] - f + (p - a);
 
         return d;
       }


### PR DESCRIPTION
array can have max size of PTRDIFF_MAX.  (... https://wandbox.org/permlink/a3o3KP7vKOUGdEzF)

And fixes the constructor to have a more "sane" CAP capacity template value.

Automatically simplifies some pointer arithmetic.